### PR TITLE
Disable polling of config parameters and update in a separate loop

### DIFF
--- a/src/eiger_fastcs/__main__.py
+++ b/src/eiger_fastcs/__main__.py
@@ -13,30 +13,24 @@ __all__ = ["main"]
 
 def get_controller() -> EigerController:
     ip_settings = IPConnectionSettings("127.0.0.1", 8080)
-    tcont = EigerController(ip_settings)
-    return tcont
+    return EigerController(ip_settings)
 
 
-# TODO: Maybe combine this with test_ioc
-def create_gui() -> None:
-    tcont = get_controller()
-    m = Mapping(tcont)
+def create_gui(controller) -> None:
+    m = Mapping(controller)
     backend = EpicsBackend(m)
     backend.create_gui()
 
 
-def test_ioc() -> None:
-    tcont = get_controller()
-    m = Mapping(tcont)
+def test_ioc(controller) -> None:
+    m = Mapping(controller)
     backend = EpicsBackend(m)
     ioc = backend.get_ioc()
-
     ioc.run()
 
 
-def test_asyncio_backend() -> None:
-    tcont = get_controller()
-    m = Mapping(tcont)
+def test_asyncio_backend(controller) -> None:
+    m = Mapping(controller)
     backend = AsyncioBackend(m)
     backend.run_interactive_session()
 
@@ -46,8 +40,9 @@ def main(args=None):
     parser.add_argument("-v", "--version", action="version", version=__version__)
     args = parser.parse_args(args)
 
-    create_gui()
-    test_ioc()
+    controller = get_controller()
+    create_gui(controller)
+    test_ioc(controller)
 
 
 # test with: python -m eiger_fastcs

--- a/src/eiger_fastcs/eiger_controller.py
+++ b/src/eiger_fastcs/eiger_controller.py
@@ -9,6 +9,18 @@ from fastcs.controller import Controller
 from fastcs.datatypes import Bool, Float, Int, String
 from fastcs.wrappers import command, scan
 
+IGNORED_PARAMETERS = [
+    "countrate_correction_table",
+    "pixel_mask",
+    "threshold/1/pixel_mask",
+    "threshold/2/pixel_mask",
+    "flatfield",
+    "threshold/1/flatfield",
+    "threshold/2/flatfield",
+    "board_000/th0_humidity",
+    "board_000/th0_temp",
+]
+
 
 @dataclass
 class EigerHandler:
@@ -131,7 +143,9 @@ class EigerController(Controller):
         for index, subsystem in enumerate(subsystems):
             for mode in modes:
                 response = await connection.get(f"{subsystem}/api/1.8.0/{mode}/keys")
-                subsystem_parameters = response["value"]
+                subsystem_parameters = [
+                    p for p in response["value"] if p not in IGNORED_PARAMETERS
+                ]
                 requests = [
                     connection.get(f"{subsystem}/api/1.8.0/{mode}/{item}")
                     for item in subsystem_parameters


### PR DESCRIPTION
Some tweaks to the FastCS core could make this a bit neater, but it works for now.