### PR TITLE
Workaround build-push-action download-artifact incompatibility

### DIFF
--- a/.github/workflows/_container.yml
+++ b/.github/workflows/_container.yml
@@ -26,6 +26,8 @@ jobs:
 
       - name: Build and export to Docker local cache
         uses: docker/build-push-action@v6
+        env:
+          DOCKER_BUILD_RECORD_UPLOAD: false
         with:
           context: .
           # Need load and tags so we can test it below
@@ -47,6 +49,8 @@ jobs:
       - name: Push cached image to container registry
         if: github.ref_type == 'tag'
         uses: docker/build-push-action@v6
+        env:
+          DOCKER_BUILD_RECORD_UPLOAD: false
         # This does not build the image again, it will find the image in the
         # Docker cache and publish it
         with:


### PR DESCRIPTION
- https://github.com/docker/build-push-action/issues/1167
- https://docs.docker.com/build/ci/github-actions/build-summary/#disable-build-record-upload

Working build: https://github.com/DiamondLightSource/eiger-fastcs/actions/runs/10183281687/job/28167943885